### PR TITLE
Phase 6 Polish: API Key fixes, client binding, and test suite

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -13,7 +13,6 @@ class Settings(BaseSettings):
 
     DATABASE_URL: str = "sqlite:///./model_router_portal.db"
     FRONTEND_URL: str = "http://localhost:5173"
-    MOCK_MODE: bool = True  # 开发环境使用 mock 数据，无需真实 AccessKey
 
 
 settings = Settings()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,6 +11,7 @@ from app.routes.models import router as models_router
 from app.routes.apikeys import router as apikeys_router
 from app.routes.balance import router as balance_router
 from app.routes.usage import router as usage_router, dashboard_router
+from app.routes.settings import router as settings_router
 
 
 @asynccontextmanager
@@ -40,6 +41,7 @@ app.include_router(apikeys_router)
 app.include_router(balance_router)
 app.include_router(usage_router)
 app.include_router(dashboard_router)
+app.include_router(settings_router)
 
 
 @app.get("/api/v1/health")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ import app.models  # noqa: F401 — ensure all models are registered before crea
 from app.routes.auth import router as auth_router
 from app.routes.models import router as models_router
 from app.routes.apikeys import router as apikeys_router
+from app.routes.balance import router as balance_router
 
 
 @asynccontextmanager
@@ -35,6 +36,7 @@ app.add_middleware(
 app.include_router(auth_router)
 app.include_router(models_router)
 app.include_router(apikeys_router)
+app.include_router(balance_router)
 
 
 @app.get("/api/v1/health")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,6 +10,7 @@ from app.routes.auth import router as auth_router
 from app.routes.models import router as models_router
 from app.routes.apikeys import router as apikeys_router
 from app.routes.balance import router as balance_router
+from app.routes.usage import router as usage_router, dashboard_router
 
 
 @asynccontextmanager
@@ -37,6 +38,8 @@ app.include_router(auth_router)
 app.include_router(models_router)
 app.include_router(apikeys_router)
 app.include_router(balance_router)
+app.include_router(usage_router)
+app.include_router(dashboard_router)
 
 
 @app.get("/api/v1/health")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,5 +1,6 @@
 from app.models.activation import UserModelActivation
 from app.models.model import Model
+from app.models.recharge import RechargeRecord
 from app.models.user import User
 
-__all__ = ["User", "Model", "UserModelActivation"]
+__all__ = ["User", "Model", "UserModelActivation", "RechargeRecord"]

--- a/backend/app/models/recharge.py
+++ b/backend/app/models/recharge.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+
+from sqlalchemy import DateTime, Float, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class RechargeRecord(Base):
+    __tablename__ = "recharge_records"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    user_id: Mapped[int] = mapped_column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    amount: Mapped[float] = mapped_column(Float, nullable=False)
+    balance_before: Mapped[float] = mapped_column(Float, nullable=False)
+    balance_after: Mapped[float] = mapped_column(Float, nullable=False)
+    status: Mapped[str] = mapped_column(String(16), default="pending")  # pending/completed/failed
+    remark: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import Boolean, DateTime, Integer, String
+from sqlalchemy import Boolean, DateTime, Float, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.database import Base
@@ -17,4 +17,5 @@ class User(Base):
     display_name: Mapped[str | None] = mapped_column(String(64), nullable=True)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     is_admin: Mapped[bool] = mapped_column(Boolean, default=False)
+    balance: Mapped[float] = mapped_column(Float, default=0.0)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)

--- a/backend/app/routes/apikeys.py
+++ b/backend/app/routes/apikeys.py
@@ -8,11 +8,14 @@ from app.services import apikey_service
 
 router = APIRouter(prefix="/api/v1/api-keys", tags=["api-keys"])
 
-MOCK_CLIENT_ID = 10001  # mock client_id for users without real Alibaba Cloud client
-
 
 def _get_client_id(user: User) -> int:
-    return user.client_id if user.client_id else MOCK_CLIENT_ID + user.id
+    if not user.client_id:
+        raise HTTPException(
+            status_code=403,
+            detail="User has no Alibaba Cloud client binding. Please contact admin.",
+        )
+    return user.client_id
 
 
 @router.get("/", response_model=list[ApiKeyListItem])
@@ -24,13 +27,35 @@ def list_keys(current_user: User = Depends(get_current_user)):
 @router.post("/", response_model=ApiKeyCreateResponse)
 def create_key(current_user: User = Depends(get_current_user)):
     client_id = _get_client_id(current_user)
-    result = apikey_service.create_api_key(client_id)
+    try:
+        result = apikey_service.create_api_key(client_id)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
     return ApiKeyCreateResponse(
         id=result["id"],
         api_key=result["api_key"],
         status=result["status"],
         created_at=result["created_at"],
     )
+
+
+@router.post("/{key_id}/copy")
+def copy_key(
+    key_id: int,
+    current_user: User = Depends(get_current_user),
+):
+    client_id = _get_client_id(current_user)
+    try:
+        result = apikey_service.copy_api_key(key_id)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return {
+        "id": result["id"],
+        "api_key": result["api_key"],
+        "api_key_preview": result["api_key_preview"],
+        "status": result["status"],
+        "created_at": result["created_at"],
+    }
 
 
 @router.delete("/{key_id}")

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -9,6 +9,7 @@ from app.schemas.auth import (
     TokenResponse,
     UserResponse,
 )
+from app.services.client_service import create_cloud_client
 from app.utils.security import create_access_token, hash_password, verify_password
 
 router = APIRouter(prefix="/api/v1/auth", tags=["auth"])
@@ -30,6 +31,22 @@ def register(req: RegisterRequest, db: Session = Depends(get_db)):
     db.add(user)
     db.commit()
     db.refresh(user)
+
+    # Create Alibaba Cloud client and bind to local user
+    try:
+        cloud_client = create_cloud_client(name=user.display_name or user.username)
+        user.client_id = cloud_client["id"]
+        user.client_uuid = cloud_client["client_uuid"]
+        db.commit()
+        db.refresh(user)
+    except Exception as exc:
+        # Rollback local user if cloud client creation fails
+        db.delete(user)
+        db.commit()
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"Failed to create Alibaba Cloud client: {exc}",
+        )
 
     token = create_access_token({"sub": user.id})
     return TokenResponse(access_token=token)

--- a/backend/app/routes/balance.py
+++ b/backend/app/routes/balance.py
@@ -22,13 +22,16 @@ def submit_recharge(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
+    balance_before = current_user.balance
+    current_user.balance += req.amount
     record = RechargeRecord(
         user_id=current_user.id,
         amount=req.amount,
-        balance_before=current_user.balance,
-        balance_after=current_user.balance,  # updated on approval
-        status="pending",
+        balance_before=balance_before,
+        balance_after=current_user.balance,
+        status="completed",
         remark=req.remark,
+        completed_at=datetime.utcnow(),
     )
     db.add(record)
     db.commit()

--- a/backend/app/routes/balance.py
+++ b/backend/app/routes/balance.py
@@ -1,0 +1,79 @@
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.dependencies import get_current_user, get_db
+from app.models.recharge import RechargeRecord
+from app.models.user import User
+from app.schemas.balance import BalanceResponse, RechargeRecordResponse, RechargeRequest
+
+router = APIRouter(prefix="/api/v1/balance", tags=["balance"])
+
+
+@router.get("/", response_model=BalanceResponse)
+def get_balance(current_user: User = Depends(get_current_user)):
+    return BalanceResponse(balance=current_user.balance)
+
+
+@router.post("/recharge", response_model=RechargeRecordResponse)
+def submit_recharge(
+    req: RechargeRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    record = RechargeRecord(
+        user_id=current_user.id,
+        amount=req.amount,
+        balance_before=current_user.balance,
+        balance_after=current_user.balance,  # updated on approval
+        status="pending",
+        remark=req.remark,
+    )
+    db.add(record)
+    db.commit()
+    db.refresh(record)
+    return record
+
+
+@router.get("/history", response_model=list[RechargeRecordResponse])
+def recharge_history(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    return (
+        db.query(RechargeRecord)
+        .filter(RechargeRecord.user_id == current_user.id)
+        .order_by(RechargeRecord.created_at.desc())
+        .limit(50)
+        .all()
+    )
+
+
+@router.post("/recharge/{record_id}/approve", response_model=RechargeRecordResponse)
+def approve_recharge(
+    record_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    if not current_user.is_admin:
+        raise HTTPException(status_code=403, detail="Admin only")
+
+    record = db.query(RechargeRecord).filter(RechargeRecord.id == record_id).first()
+    if not record:
+        raise HTTPException(status_code=404, detail="Record not found")
+    if record.status != "pending":
+        raise HTTPException(status_code=400, detail="Record is not pending")
+
+    user = db.query(User).filter(User.id == record.user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    record.balance_before = user.balance
+    user.balance += record.amount
+    record.balance_after = user.balance
+    record.status = "completed"
+    record.completed_at = datetime.utcnow()
+    db.commit()
+    db.refresh(record)
+    return record

--- a/backend/app/routes/settings.py
+++ b/backend/app/routes/settings.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.dependencies import get_current_user, get_db
+from app.models.user import User
+from app.schemas.settings import ChangePasswordRequest
+from app.utils.security import hash_password, verify_password
+from sqlalchemy.orm import Session
+
+router = APIRouter(prefix="/api/v1/settings", tags=["settings"])
+
+
+@router.put("/password")
+def change_password(
+    req: ChangePasswordRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    if not verify_password(req.old_password, current_user.hashed_password):
+        raise HTTPException(status_code=400, detail="原密码不正确")
+    current_user.hashed_password = hash_password(req.new_password)
+    db.commit()
+    return {"detail": "密码修改成功"}

--- a/backend/app/routes/usage.py
+++ b/backend/app/routes/usage.py
@@ -1,10 +1,8 @@
-"""Usage & Dashboard routes — mock data in MOCK_MODE, real SDK calls otherwise."""
-import random
-from datetime import datetime, timedelta
+"""Usage & Dashboard routes — real SDK calls (TODO: implement)."""
+from datetime import datetime
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends
 
-from app.config import settings
 from app.dependencies import get_current_user, get_db
 from app.models.activation import UserModelActivation
 from app.models.user import User
@@ -18,69 +16,20 @@ from sqlalchemy.orm import Session
 
 router = APIRouter(prefix="/api/v1/usage", tags=["usage"])
 
-# Mock model names
-_MODEL_NAMES = {
-    "qwen3.6-plus": "Qwen3.6-Plus",
-    "qwen3-max": "Qwen3-Max",
-    "kimi-k2.6": "Kimi-K2.6",
-    "deepseek-v4-pro": "DeepSeek-V4-Pro",
-}
-
-
-def _mock_trend(days: int = 7) -> list[UsageTrendItem]:
-    today = datetime.utcnow().date()
-    result = []
-    for i in range(days - 1, -1, -1):
-        d = today - timedelta(days=i)
-        cost = round(random.uniform(0.5, 15.0), 2)
-        tokens = random.randint(1000, 50000)
-        requests = random.randint(5, 200)
-        result.append(
-            UsageTrendItem(
-                date=d.isoformat(),
-                cost=cost,
-                tokens=tokens,
-                requests=requests,
-            )
-        )
-    return result
-
-
-def _mock_model_usage() -> list[ModelUsageItem]:
-    return [
-        ModelUsageItem(
-            model_id=mid,
-            model_name=name,
-            cost=round(random.uniform(5.0, 100.0), 2),
-            tokens=random.randint(10000, 500000),
-            requests=random.randint(50, 2000),
-        )
-        for mid, name in _MODEL_NAMES.items()
-    ]
-
 
 @router.get("/overview", response_model=UsageOverview)
 def usage_overview(
     current_user: User = Depends(get_current_user),
 ):
-    if settings.MOCK_MODE:
-        return UsageOverview(
-            total_cost=round(random.uniform(20.0, 200.0), 2),
-            total_tokens=random.randint(100000, 1000000),
-            total_requests=random.randint(500, 5000),
-            period=datetime.utcnow().strftime("%Y-%m"),
-        )
     # TODO: real SDK call
     return UsageOverview(total_cost=0, total_tokens=0, total_requests=0, period="")
 
 
 @router.get("/trend", response_model=list[UsageTrendItem])
 def usage_trend(
-    days: int = Query(default=7, ge=1, le=30),
     current_user: User = Depends(get_current_user),
 ):
-    if settings.MOCK_MODE:
-        return _mock_trend(days)
+    # TODO: real SDK call
     return []
 
 
@@ -88,8 +37,7 @@ def usage_trend(
 def usage_by_model(
     current_user: User = Depends(get_current_user),
 ):
-    if settings.MOCK_MODE:
-        return _mock_model_usage()
+    # TODO: real SDK call
     return []
 
 
@@ -111,14 +59,10 @@ def get_dashboard(
         .count()
     )
 
-    trend = _mock_trend(7) if settings.MOCK_MODE else []
-    total_cost = round(sum(t.cost for t in trend), 2)
-    total_requests = sum(t.requests for t in trend)
-
     return DashboardData(
         balance=current_user.balance,
-        total_cost_30d=total_cost,
-        total_requests_30d=total_requests,
+        total_cost_30d=0,
+        total_requests_30d=0,
         activated_models=activated_count,
-        recent_trend=trend,
+        recent_trend=[],
     )

--- a/backend/app/routes/usage.py
+++ b/backend/app/routes/usage.py
@@ -1,0 +1,124 @@
+"""Usage & Dashboard routes — mock data in MOCK_MODE, real SDK calls otherwise."""
+import random
+from datetime import datetime, timedelta
+
+from fastapi import APIRouter, Depends, Query
+
+from app.config import settings
+from app.dependencies import get_current_user, get_db
+from app.models.activation import UserModelActivation
+from app.models.user import User
+from app.schemas.usage import (
+    DashboardData,
+    ModelUsageItem,
+    UsageOverview,
+    UsageTrendItem,
+)
+from sqlalchemy.orm import Session
+
+router = APIRouter(prefix="/api/v1/usage", tags=["usage"])
+
+# Mock model names
+_MODEL_NAMES = {
+    "qwen3.6-plus": "Qwen3.6-Plus",
+    "qwen3-max": "Qwen3-Max",
+    "kimi-k2.6": "Kimi-K2.6",
+    "deepseek-v4-pro": "DeepSeek-V4-Pro",
+}
+
+
+def _mock_trend(days: int = 7) -> list[UsageTrendItem]:
+    today = datetime.utcnow().date()
+    result = []
+    for i in range(days - 1, -1, -1):
+        d = today - timedelta(days=i)
+        cost = round(random.uniform(0.5, 15.0), 2)
+        tokens = random.randint(1000, 50000)
+        requests = random.randint(5, 200)
+        result.append(
+            UsageTrendItem(
+                date=d.isoformat(),
+                cost=cost,
+                tokens=tokens,
+                requests=requests,
+            )
+        )
+    return result
+
+
+def _mock_model_usage() -> list[ModelUsageItem]:
+    return [
+        ModelUsageItem(
+            model_id=mid,
+            model_name=name,
+            cost=round(random.uniform(5.0, 100.0), 2),
+            tokens=random.randint(10000, 500000),
+            requests=random.randint(50, 2000),
+        )
+        for mid, name in _MODEL_NAMES.items()
+    ]
+
+
+@router.get("/overview", response_model=UsageOverview)
+def usage_overview(
+    current_user: User = Depends(get_current_user),
+):
+    if settings.MOCK_MODE:
+        return UsageOverview(
+            total_cost=round(random.uniform(20.0, 200.0), 2),
+            total_tokens=random.randint(100000, 1000000),
+            total_requests=random.randint(500, 5000),
+            period=datetime.utcnow().strftime("%Y-%m"),
+        )
+    # TODO: real SDK call
+    return UsageOverview(total_cost=0, total_tokens=0, total_requests=0, period="")
+
+
+@router.get("/trend", response_model=list[UsageTrendItem])
+def usage_trend(
+    days: int = Query(default=7, ge=1, le=30),
+    current_user: User = Depends(get_current_user),
+):
+    if settings.MOCK_MODE:
+        return _mock_trend(days)
+    return []
+
+
+@router.get("/models", response_model=list[ModelUsageItem])
+def usage_by_model(
+    current_user: User = Depends(get_current_user),
+):
+    if settings.MOCK_MODE:
+        return _mock_model_usage()
+    return []
+
+
+# Dashboard endpoint — aggregates key metrics
+dashboard_router = APIRouter(prefix="/api/v1/dashboard", tags=["dashboard"])
+
+
+@dashboard_router.get("/", response_model=DashboardData)
+def get_dashboard(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    activated_count = (
+        db.query(UserModelActivation)
+        .filter(
+            UserModelActivation.user_id == current_user.id,
+            UserModelActivation.status == "active",
+        )
+        .count()
+    )
+
+    trend = _mock_trend(7) if settings.MOCK_MODE else []
+    total_cost = round(sum(t.cost for t in trend), 2)
+    total_requests = sum(t.requests for t in trend)
+
+    return DashboardData(
+        balance=current_user.balance,
+        total_cost_30d=total_cost,
+        total_requests_30d=total_requests,
+        activated_models=activated_count,
+        recent_trend=trend,
+    )

--- a/backend/app/schemas/apikey.py
+++ b/backend/app/schemas/apikey.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel
 
 class ApiKeyCreateResponse(BaseModel):
     id: int | None
-    api_key: str
+    api_key: str | None
     status: str
     created_at: str
 

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -24,5 +24,6 @@ class UserResponse(BaseModel):
     client_id: int | None
     is_active: bool
     is_admin: bool
+    balance: float
 
     model_config = {"from_attributes": True}

--- a/backend/app/schemas/balance.py
+++ b/backend/app/schemas/balance.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class BalanceResponse(BaseModel):
+    balance: float
+
+
+class RechargeRequest(BaseModel):
+    amount: float = Field(..., gt=0, le=100000)
+    remark: str | None = None
+
+
+class RechargeRecordResponse(BaseModel):
+    id: int
+    amount: float
+    balance_before: float
+    balance_after: float
+    status: str
+    remark: str | None
+    created_at: datetime
+    completed_at: datetime | None
+
+    model_config = {"from_attributes": True}

--- a/backend/app/schemas/settings.py
+++ b/backend/app/schemas/settings.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel, Field
+
+
+class ChangePasswordRequest(BaseModel):
+    old_password: str
+    new_password: str = Field(..., min_length=6, max_length=128)

--- a/backend/app/schemas/usage.py
+++ b/backend/app/schemas/usage.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class UsageOverview(BaseModel):
+    total_cost: float
+    total_tokens: int
+    total_requests: int
+    period: str  # e.g. "2026-04"
+
+
+class UsageTrendItem(BaseModel):
+    date: str
+    cost: float
+    tokens: int
+    requests: int
+
+
+class ModelUsageItem(BaseModel):
+    model_id: str
+    model_name: str
+    cost: float
+    tokens: int
+    requests: int
+
+
+class DashboardData(BaseModel):
+    balance: float
+    total_cost_30d: float
+    total_requests_30d: int
+    activated_models: int
+    recent_trend: list[UsageTrendItem]

--- a/backend/app/services/apikey_service.py
+++ b/backend/app/services/apikey_service.py
@@ -1,19 +1,9 @@
-"""API Key management service — wraps Alibaba Cloud SDK calls with mock fallback."""
-import secrets
-import time
+"""API Key management service — wraps Alibaba Cloud SDK calls."""
 from datetime import datetime
 
 from alibabacloud_aicontent20240611 import models as aicontent_models
 
-from app.config import settings
 from app.services.alicloud_client import get_alicloud_client
-
-# ---------- Mock storage (in-memory, per-process) ----------
-_mock_store: dict[int, list[dict]] = {}
-
-
-def _mock_api_key_id():
-    return int(time.time() * 1000) % 10000000
 
 
 def _mask_key(key: str) -> str:
@@ -24,18 +14,6 @@ def _mask_key(key: str) -> str:
 
 def create_api_key(client_id: int) -> dict:
     """Create an API Key for the given client. Returns dict with id, api_key, etc."""
-    if settings.MOCK_MODE:
-        key_value = f"sk-mock-{secrets.token_hex(24)}"
-        record = {
-            "id": _mock_api_key_id(),
-            "api_key": key_value,
-            "client_id": client_id,
-            "status": "active",
-            "created_at": datetime.utcnow().isoformat(),
-        }
-        _mock_store.setdefault(client_id, []).append(record)
-        return record
-
     client = get_alicloud_client()
     req = aicontent_models.ModelRouterCreateApiKeyRequest(client_id=client_id)
     resp = client.model_router_create_api_key(req)
@@ -54,17 +32,6 @@ def create_api_key(client_id: int) -> dict:
 
 def list_api_keys(client_id: int) -> list[dict]:
     """List all API Keys for the given client."""
-    if settings.MOCK_MODE:
-        return [
-            {
-                "id": k["id"],
-                "api_key_preview": _mask_key(k["api_key"]),
-                "status": k["status"],
-                "created_at": k["created_at"],
-            }
-            for k in _mock_store.get(client_id, [])
-        ]
-
     client = get_alicloud_client()
     req = aicontent_models.ModelRouterQueryApiKeyListRequest(
         client_id=client_id,
@@ -89,11 +56,6 @@ def list_api_keys(client_id: int) -> list[dict]:
 
 def delete_api_key(key_id: int, client_id: int) -> bool:
     """Delete an API Key by its ID."""
-    if settings.MOCK_MODE:
-        keys = _mock_store.get(client_id, [])
-        _mock_store[client_id] = [k for k in keys if k["id"] != key_id]
-        return True
-
     client = get_alicloud_client()
     resp = client.model_router_delete_api_key(key_id)
     body = resp.body

--- a/backend/app/services/apikey_service.py
+++ b/backend/app/services/apikey_service.py
@@ -1,9 +1,12 @@
 """API Key management service — wraps Alibaba Cloud SDK calls."""
+import logging
 from datetime import datetime
 
 from alibabacloud_aicontent20240611 import models as aicontent_models
 
 from app.services.alicloud_client import get_alicloud_client
+
+logger = logging.getLogger(__name__)
 
 
 def _mask_key(key: str) -> str:
@@ -21,12 +24,27 @@ def create_api_key(client_id: int) -> dict:
     if not body.success:
         raise Exception(body.err_message or "Failed to create API Key")
     data = body.data
+    # Log raw response for debugging
+    raw = data.to_map() if data else {}
+    logger.info("CreateApiKey raw response data: %s", raw)
+
+    # Extract the key - try multiple possible field names
+    api_key = None
+    if data:
+        api_key = getattr(data, "key", None)
+        if api_key is None:
+            # Fallback: check raw map for alternative field names
+            api_key = raw.get("key") or raw.get("apiKey") or raw.get("api_key")
+
+    if api_key is None:
+        logger.warning("API Key created but full key not returned in response. Raw: %s", raw)
+
     return {
-        "id": getattr(data, "id", None),
-        "api_key": getattr(data, "api_key", None),
+        "id": getattr(data, "id", None) if data else None,
+        "api_key": api_key,
         "client_id": client_id,
         "status": "active",
-        "created_at": datetime.utcnow().isoformat(),
+        "created_at": (getattr(data, "gmt_create", None) if data else None) or datetime.utcnow().isoformat(),
     }
 
 
@@ -46,18 +64,35 @@ def list_api_keys(client_id: int) -> list[dict]:
     return [
         {
             "id": getattr(item, "id", None),
-            "api_key_preview": _mask_key(getattr(item, "api_key", "")) if getattr(item, "api_key", None) else "sk-****",
-            "status": getattr(item, "status", "active"),
+            "api_key_preview": getattr(item, "key_preview", None) or (_mask_key(getattr(item, "key", "")) if getattr(item, "key", None) else "sk-****"),
+            "status": "active" if not getattr(item, "delete_tag", 0) else "deleted",
             "created_at": getattr(item, "gmt_create", None),
         }
         for item in items
     ]
 
 
+def copy_api_key(key_id: int) -> dict:
+    """Copy (reveal) an API Key by its ID. Returns dict with full key."""
+    client = get_alicloud_client()
+    resp = client.model_router_copy_api_key(str(key_id))
+    body = resp.body
+    if not body or not body.success:
+        raise Exception(body.err_message or "Failed to copy API Key")
+    data = body.data
+    return {
+        "id": getattr(data, "id", None),
+        "api_key": getattr(data, "key", None),
+        "api_key_preview": getattr(data, "key_preview", None),
+        "status": "active" if not getattr(data, "delete_tag", 0) else "deleted",
+        "created_at": getattr(data, "gmt_create", None),
+    }
+
+
 def delete_api_key(key_id: int, client_id: int) -> bool:
     """Delete an API Key by its ID."""
     client = get_alicloud_client()
-    resp = client.model_router_delete_api_key(key_id)
+    resp = client.model_router_delete_api_key(str(key_id))
     body = resp.body
     if not body.success:
         raise Exception(body.err_message or "Failed to delete API Key")

--- a/backend/app/services/client_service.py
+++ b/backend/app/services/client_service.py
@@ -1,0 +1,25 @@
+"""Alibaba Cloud ModelRouter client creation service."""
+from alibabacloud_aicontent20240611 import models as aicontent_models
+
+from app.services.alicloud_client import get_alicloud_client
+
+
+def create_cloud_client(name: str) -> dict:
+    """
+    Create a client on Alibaba Cloud ModelRouter.
+
+    Returns a dict with:
+        - id (int): Alibaba Cloud client ID
+        - client_uuid (str): Alibaba Cloud client UUID
+    """
+    client = get_alicloud_client()
+    req = aicontent_models.ModelRouterCreateClientRequest(name=name)
+    resp = client.model_router_create_client(req)
+    body = resp.body
+    if not body or not body.success:
+        raise Exception(body.err_message or "Failed to create Alibaba Cloud client")
+    data = body.data
+    return {
+        "id": getattr(data, "id", None),
+        "client_uuid": getattr(data, "client_uuid", None),
+    }

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,6 @@ alibabacloud-openapi-util>=0.2.0
 python-multipart>=0.0.9
 python-dotenv>=1.0.0
 aiosqlite>=0.20.0
+pytest>=8.0
+pytest-asyncio>=0.23
+httpx>=0.27

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,217 @@
+"""
+Shared test fixtures for ModelRouter Portal backend tests.
+
+Uses an in-memory SQLite database so every test session starts with a clean slate.
+httpx.AsyncClient + ASGITransport drives requests through the real FastAPI app
+without needing a running server.
+"""
+
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from httpx import ASGITransport, AsyncClient
+
+from app.database import Base
+from app.dependencies import get_db
+from app.models.model import Model
+from app.routes.models import SEED_MODELS
+
+# ── ensure all ORM models are imported so Base.metadata is complete ──
+import app.models  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# Database engine & session (in-memory SQLite, sync)
+# ---------------------------------------------------------------------------
+
+TEST_DATABASE_URL = "sqlite://"  # in-memory
+
+engine = create_engine(
+    TEST_DATABASE_URL,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def override_get_db():
+    """Yield a test-scoped database session."""
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# App fixture — override dependencies, create/drop tables per session
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="session", autouse=True)
+def _create_tables():
+    """Create all tables once for the entire test session."""
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(autouse=True)
+def _clean_tables():
+    """
+    Truncate every table between tests so each test starts with a clean DB.
+    Seed models are re-inserted after truncation.
+    """
+    yield
+    # After each test, delete all rows
+    db = TestingSessionLocal()
+    try:
+        for table in reversed(Base.metadata.sorted_tables):
+            db.execute(table.delete())
+        db.commit()
+    finally:
+        db.close()
+
+
+@pytest.fixture(scope="session")
+def app():
+    """
+    Return the FastAPI application with the DB dependency overridden.
+    We import `app` from main *after* tables are created so the lifespan
+    init_db() call is harmless (tables already exist).
+    """
+    from app.main import app as _app
+
+    _app.dependency_overrides[get_db] = override_get_db
+    yield _app
+    _app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Mock Alibaba Cloud client creation
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def mock_create_cloud_client():
+    """
+    Mock create_cloud_client so tests don't need real Alibaba Cloud credentials.
+    Every registered test user automatically gets client_id=12345.
+    """
+    with patch("app.routes.auth.create_cloud_client") as mock:
+        mock.return_value = {"id": 12345, "client_uuid": "mock-uuid-12345"}
+        yield
+
+
+# ---------------------------------------------------------------------------
+# Seed models helper
+# ---------------------------------------------------------------------------
+
+def _seed_models() -> None:
+    """Insert the four default models into the test database."""
+    db = TestingSessionLocal()
+    try:
+        if db.query(Model).count() == 0:
+            for m in SEED_MODELS:
+                db.add(Model(**m))
+            db.commit()
+    finally:
+        db.close()
+
+
+@pytest.fixture(autouse=True)
+def seed_models():
+    """Ensure seed models exist before every test."""
+    _seed_models()
+
+
+# ---------------------------------------------------------------------------
+# Async HTTP client
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def async_client(app):
+    """httpx AsyncClient that talks to the FastAPI app via ASGI transport."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+# ---------------------------------------------------------------------------
+# User helpers
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def test_user(async_client: AsyncClient):
+    """
+    Register a normal test user and return a dict with token + user info.
+    """
+    resp = await async_client.post(
+        "/api/v1/auth/register",
+        json={"username": "testuser", "password": "TestPass123!"},
+    )
+    assert resp.status_code == 200, f"Register failed: {resp.text}"
+    data = resp.json()
+
+    # Fetch user profile
+    headers = {"Authorization": f"Bearer {data['access_token']}"}
+    me_resp = await async_client.get("/api/v1/auth/me", headers=headers)
+    assert me_resp.status_code == 200
+    user_info = me_resp.json()
+
+    return {
+        "token": data["access_token"],
+        "user": user_info,
+    }
+
+
+@pytest_asyncio.fixture
+async def admin_user(async_client: AsyncClient):
+    """
+    Register a user, then promote to admin directly in the database.
+    Returns dict with token + user info.
+    """
+    resp = await async_client.post(
+        "/api/v1/auth/register",
+        json={"username": "adminuser", "password": "AdminPass123!"},
+    )
+    assert resp.status_code == 200, f"Register admin failed: {resp.text}"
+    data = resp.json()
+
+    # Promote to admin in DB
+    from app.models.user import User
+
+    db = TestingSessionLocal()
+    try:
+        user = db.query(User).filter(User.username == "adminuser").first()
+        assert user is not None
+        user.is_admin = True
+        db.commit()
+    finally:
+        db.close()
+
+    # Fetch user profile (will now show is_admin=True)
+    headers = {"Authorization": f"Bearer {data['access_token']}"}
+    me_resp = await async_client.get("/api/v1/auth/me", headers=headers)
+    assert me_resp.status_code == 200
+    user_info = me_resp.json()
+
+    return {
+        "token": data["access_token"],
+        "user": user_info,
+    }
+
+
+@pytest_asyncio.fixture
+async def auth_headers(test_user: dict) -> dict:
+    """Authorization headers for the normal test user."""
+    return {"Authorization": f"Bearer {test_user['token']}"}
+
+
+@pytest_asyncio.fixture
+async def admin_headers(admin_user: dict) -> dict:
+    """Authorization headers for the admin user."""
+    return {"Authorization": f"Bearer {admin_user['token']}"}

--- a/backend/tests/test_apikeys.py
+++ b/backend/tests/test_apikeys.py
@@ -1,0 +1,115 @@
+"""Tests for API Key management endpoints."""
+
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+
+from tests.conftest import TestingSessionLocal
+from app.models.user import User
+
+
+@pytest.fixture(autouse=True)
+def _set_client_id_on_users():
+    """
+    After each test's user creation, ensure test users have a client_id
+    so they pass the _get_client_id check in the apikeys route.
+    We do this as a yield fixture: set client_id before test body runs
+    only if users already exist (they won't at this point), so we also
+    patch in each test as needed.
+    """
+    yield
+
+
+def _set_user_client_id(username: str, client_id: int = 12345):
+    """Helper: set client_id on a user in the test DB."""
+    db = TestingSessionLocal()
+    try:
+        user = db.query(User).filter(User.username == username).first()
+        if user:
+            user.client_id = client_id
+            db.commit()
+    finally:
+        db.close()
+
+
+MOCK_CREATE_RESULT = {
+    "id": 1001,
+    "api_key": "sk-test-1234567890abcdef",
+    "client_id": 12345,
+    "status": "active",
+    "created_at": "2026-04-29T00:00:00",
+}
+
+MOCK_LIST_RESULT = [
+    {
+        "id": 1001,
+        "api_key_preview": "sk-tes****cdef",
+        "status": "active",
+        "created_at": "2026-04-29T00:00:00",
+    }
+]
+
+
+async def test_create_api_key(async_client: AsyncClient, test_user: dict):
+    """POST /api/v1/api-keys/ should return 200 with full api_key."""
+    _set_user_client_id("testuser")
+    headers = {"Authorization": f"Bearer {test_user['token']}"}
+
+    with patch("app.routes.apikeys.apikey_service.create_api_key", return_value=MOCK_CREATE_RESULT):
+        resp = await async_client.post("/api/v1/api-keys/", headers=headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "api_key" in data
+    assert data["api_key"] == "sk-test-1234567890abcdef"
+    assert data["status"] == "active"
+    assert data["id"] == 1001
+
+
+async def test_list_api_keys(async_client: AsyncClient, test_user: dict):
+    """GET /api/v1/api-keys/ should return 200 with masked api_key_preview."""
+    _set_user_client_id("testuser")
+    headers = {"Authorization": f"Bearer {test_user['token']}"}
+
+    with patch("app.routes.apikeys.apikey_service.list_api_keys", return_value=MOCK_LIST_RESULT):
+        resp = await async_client.get("/api/v1/api-keys/", headers=headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert len(data) == 1
+    # Verify the key is masked (contains ****)
+    assert "****" in data[0]["api_key_preview"]
+
+
+async def test_delete_api_key(async_client: AsyncClient, test_user: dict):
+    """DELETE /api/v1/api-keys/{id} should return 200."""
+    _set_user_client_id("testuser")
+    headers = {"Authorization": f"Bearer {test_user['token']}"}
+
+    with patch("app.routes.apikeys.apikey_service.delete_api_key", return_value=True):
+        resp = await async_client.delete("/api/v1/api-keys/1001", headers=headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["detail"] == "API Key deleted"
+
+
+async def test_create_key_without_auth(async_client: AsyncClient):
+    """POST /api/v1/api-keys/ without auth should return 401 (no credentials)."""
+    resp = await async_client.post("/api/v1/api-keys/")
+    assert resp.status_code in (401, 403)
+
+
+async def test_list_empty_keys(async_client: AsyncClient, test_user: dict):
+    """GET /api/v1/api-keys/ should return 200 with empty list when no keys exist."""
+    _set_user_client_id("testuser")
+    headers = {"Authorization": f"Bearer {test_user['token']}"}
+
+    with patch("app.routes.apikeys.apikey_service.list_api_keys", return_value=[]):
+        resp = await async_client.get("/api/v1/api-keys/", headers=headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data == []

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,95 @@
+"""Integration tests for /api/v1/auth endpoints."""
+
+import pytest
+from httpx import AsyncClient
+
+
+# ---------------------------------------------------------------------------
+# POST /register
+# ---------------------------------------------------------------------------
+
+async def test_register_success(async_client: AsyncClient):
+    resp = await async_client.post(
+        "/api/v1/auth/register",
+        json={"username": "newuser", "password": "StrongPass1!"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "access_token" in data
+    assert data["token_type"] == "bearer"
+
+
+async def test_register_duplicate_username(async_client: AsyncClient):
+    # Register first time
+    await async_client.post(
+        "/api/v1/auth/register",
+        json={"username": "dupuser", "password": "StrongPass1!"},
+    )
+    # Register again with same username
+    resp = await async_client.post(
+        "/api/v1/auth/register",
+        json={"username": "dupuser", "password": "AnotherPass1!"},
+    )
+    assert resp.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# POST /login
+# ---------------------------------------------------------------------------
+
+async def test_login_success(async_client: AsyncClient):
+    # Setup: register user first
+    await async_client.post(
+        "/api/v1/auth/register",
+        json={"username": "loginuser", "password": "LoginPass1!"},
+    )
+    resp = await async_client.post(
+        "/api/v1/auth/login",
+        json={"username": "loginuser", "password": "LoginPass1!"},
+    )
+    assert resp.status_code == 200
+    assert "access_token" in resp.json()
+
+
+async def test_login_wrong_password(async_client: AsyncClient):
+    await async_client.post(
+        "/api/v1/auth/register",
+        json={"username": "wrongpwuser", "password": "CorrectPass1!"},
+    )
+    resp = await async_client.post(
+        "/api/v1/auth/login",
+        json={"username": "wrongpwuser", "password": "WrongPass999!"},
+    )
+    assert resp.status_code == 401
+
+
+async def test_login_nonexistent_user(async_client: AsyncClient):
+    resp = await async_client.post(
+        "/api/v1/auth/login",
+        json={"username": "ghost", "password": "NoOne123!"},
+    )
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /me
+# ---------------------------------------------------------------------------
+
+async def test_get_me_authenticated(async_client: AsyncClient, auth_headers: dict):
+    resp = await async_client.get("/api/v1/auth/me", headers=auth_headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["username"] == "testuser"
+    assert "id" in data
+    assert "is_active" in data
+
+
+async def test_get_me_no_token(async_client: AsyncClient):
+    resp = await async_client.get("/api/v1/auth/me")
+    assert resp.status_code == 401  # HTTPBearer auto_error=True -> 401 (no credentials)
+
+
+async def test_get_me_invalid_token(async_client: AsyncClient):
+    headers = {"Authorization": "Bearer invalid.jwt.token"}
+    resp = await async_client.get("/api/v1/auth/me", headers=headers)
+    assert resp.status_code == 401

--- a/backend/tests/test_balance.py
+++ b/backend/tests/test_balance.py
@@ -1,0 +1,110 @@
+"""Tests for balance and recharge endpoints."""
+
+from httpx import AsyncClient
+
+
+async def test_get_balance(async_client: AsyncClient, auth_headers: dict):
+    """GET /api/v1/balance/ should return 200 with initial balance=0."""
+    resp = await async_client.get("/api/v1/balance/", headers=auth_headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "balance" in data
+    assert data["balance"] == 0.0
+
+
+async def test_submit_recharge(async_client: AsyncClient, auth_headers: dict):
+    """POST /api/v1/balance/recharge should return 200 with status=completed."""
+    resp = await async_client.post(
+        "/api/v1/balance/recharge",
+        json={"amount": 100.0, "remark": "test recharge"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "completed"
+    assert data["amount"] == 100.0
+    assert data["remark"] == "test recharge"
+    assert data["balance_after"] == 100.0
+
+
+async def test_recharge_invalid_amount(async_client: AsyncClient, auth_headers: dict):
+    """POST /api/v1/balance/recharge with invalid amount should return 422."""
+    # amount <= 0 violates gt=0 constraint
+    resp = await async_client.post(
+        "/api/v1/balance/recharge",
+        json={"amount": -10.0},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 422
+
+    # amount > 100000 violates le=100000 constraint
+    resp = await async_client.post(
+        "/api/v1/balance/recharge",
+        json={"amount": 200000.0},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 422
+
+
+async def test_recharge_history(async_client: AsyncClient, auth_headers: dict):
+    """GET /api/v1/balance/history should return 200 with recharge records."""
+    # First submit a recharge
+    await async_client.post(
+        "/api/v1/balance/recharge",
+        json={"amount": 50.0},
+        headers=auth_headers,
+    )
+
+    resp = await async_client.get("/api/v1/balance/history", headers=auth_headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert len(data) >= 1
+    assert data[0]["amount"] == 50.0
+
+
+async def test_admin_approve_recharge(
+    async_client: AsyncClient,
+    test_user: dict,
+    admin_headers: dict,
+):
+    """Recharge now completes immediately; verify balance is updated."""
+    user_headers = {"Authorization": f"Bearer {test_user['token']}"}
+
+    # Submit recharge as normal user — should complete immediately
+    resp = await async_client.post(
+        "/api/v1/balance/recharge",
+        json={"amount": 200.0},
+        headers=user_headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "completed"
+    assert data["balance_after"] == 200.0
+
+    # Verify balance updated
+    resp = await async_client.get("/api/v1/balance/", headers=user_headers)
+    assert resp.status_code == 200
+    assert resp.json()["balance"] == 200.0
+
+
+async def test_non_admin_approve(
+    async_client: AsyncClient,
+    auth_headers: dict,
+):
+    """POST /api/v1/balance/recharge/{id}/approve as non-admin should return 403."""
+    # Submit a recharge first
+    resp = await async_client.post(
+        "/api/v1/balance/recharge",
+        json={"amount": 100.0},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    record_id = resp.json()["id"]
+
+    # Try to approve as non-admin
+    resp = await async_client.post(
+        f"/api/v1/balance/recharge/{record_id}/approve",
+        headers=auth_headers,
+    )
+    assert resp.status_code == 403

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -1,0 +1,114 @@
+"""Integration tests for /api/v1/models endpoints."""
+
+import pytest
+from httpx import AsyncClient
+
+MODEL_ID = "qwen3.6-plus"
+
+
+# ---------------------------------------------------------------------------
+# GET /models/
+# ---------------------------------------------------------------------------
+
+async def test_list_models(async_client: AsyncClient):
+    resp = await async_client.get("/api/v1/models/")
+    assert resp.status_code == 200
+    models = resp.json()
+    assert isinstance(models, list)
+    assert len(models) == 4
+    model_ids = {m["model_id"] for m in models}
+    assert MODEL_ID in model_ids
+
+
+# ---------------------------------------------------------------------------
+# GET /models/{model_id}
+# ---------------------------------------------------------------------------
+
+async def test_get_model_detail_public(async_client: AsyncClient):
+    resp = await async_client.get(f"/api/v1/models/{MODEL_ID}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["model_id"] == MODEL_ID
+    assert "name" in data
+    assert "provider" in data
+    # Without auth, activated defaults to False
+    assert data["activated"] is False
+
+
+async def test_get_model_detail_with_auth(async_client: AsyncClient, auth_headers: dict):
+    resp = await async_client.get(f"/api/v1/models/{MODEL_ID}", headers=auth_headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["model_id"] == MODEL_ID
+    assert "activated" in data
+
+
+async def test_get_model_not_found(async_client: AsyncClient):
+    resp = await async_client.get("/api/v1/models/nonexistent")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /models/{model_id}/activate
+# ---------------------------------------------------------------------------
+
+async def test_activate_model(async_client: AsyncClient, auth_headers: dict):
+    resp = await async_client.post(
+        f"/api/v1/models/{MODEL_ID}/activate", headers=auth_headers
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "active"
+    assert data["model_id"] == MODEL_ID
+
+
+async def test_activate_already_active(async_client: AsyncClient, auth_headers: dict):
+    # Activate first
+    await async_client.post(
+        f"/api/v1/models/{MODEL_ID}/activate", headers=auth_headers
+    )
+    # Try again
+    resp = await async_client.post(
+        f"/api/v1/models/{MODEL_ID}/activate", headers=auth_headers
+    )
+    assert resp.status_code == 409
+
+
+async def test_activate_without_auth(async_client: AsyncClient):
+    resp = await async_client.post(f"/api/v1/models/{MODEL_ID}/activate")
+    assert resp.status_code == 401  # HTTPBearer auto_error -> 401 (no credentials)
+
+
+# ---------------------------------------------------------------------------
+# POST /models/{model_id}/deactivate
+# ---------------------------------------------------------------------------
+
+async def test_deactivate_model(async_client: AsyncClient, auth_headers: dict):
+    # Activate first
+    await async_client.post(
+        f"/api/v1/models/{MODEL_ID}/activate", headers=auth_headers
+    )
+    # Deactivate
+    resp = await async_client.post(
+        f"/api/v1/models/{MODEL_ID}/deactivate", headers=auth_headers
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "deactivated"
+
+
+# ---------------------------------------------------------------------------
+# GET /models/activated
+# ---------------------------------------------------------------------------
+
+async def test_list_activated_models(async_client: AsyncClient, auth_headers: dict):
+    # Activate a model first
+    await async_client.post(
+        f"/api/v1/models/{MODEL_ID}/activate", headers=auth_headers
+    )
+    resp = await async_client.get("/api/v1/models/activated", headers=auth_headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert len(data) >= 1
+    assert any(a["model_id"] == MODEL_ID for a in data)

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -1,0 +1,56 @@
+"""Unit tests for app/utils/security.py."""
+
+from datetime import datetime, timedelta
+
+from jose import jwt
+
+from app.config import settings
+from app.utils.security import (
+    ALGORITHM,
+    create_access_token,
+    decode_access_token,
+    hash_password,
+    verify_password,
+)
+
+
+def test_hash_password():
+    hashed = hash_password("mysecret")
+    assert hashed  # non-empty
+    assert hashed != "mysecret"  # not plaintext
+
+
+def test_verify_password_correct():
+    hashed = hash_password("mysecret")
+    assert verify_password("mysecret", hashed) is True
+
+
+def test_verify_password_wrong():
+    hashed = hash_password("mysecret")
+    assert verify_password("wrongpassword", hashed) is False
+
+
+def test_create_access_token():
+    token = create_access_token({"sub": 42})
+    assert isinstance(token, str)
+    assert len(token) > 0
+
+
+def test_decode_access_token():
+    token = create_access_token({"sub": 42})
+    payload = decode_access_token(token)
+    assert payload is not None
+    assert payload["sub"] == "42"  # sub is cast to str
+
+
+def test_decode_expired_token():
+    """A token with an already-past expiry should return None."""
+    to_encode = {"sub": "1"}
+    expire = datetime.utcnow() + timedelta(minutes=-1)
+    to_encode["exp"] = expire
+    token = jwt.encode(to_encode, settings.SECRET_KEY, algorithm=ALGORITHM)
+    assert decode_access_token(token) is None
+
+
+def test_decode_invalid_token():
+    assert decode_access_token("this-is-not-a-jwt") is None

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -1,0 +1,54 @@
+"""Tests for account settings endpoints."""
+
+from httpx import AsyncClient
+
+
+async def test_change_password_success(async_client: AsyncClient, test_user: dict):
+    """PUT /api/v1/settings/password should succeed and allow login with new password."""
+    headers = {"Authorization": f"Bearer {test_user['token']}"}
+
+    resp = await async_client.put(
+        "/api/v1/settings/password",
+        json={"old_password": "TestPass123!", "new_password": "NewPass456!"},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+
+    # Verify login with new password works
+    resp = await async_client.post(
+        "/api/v1/auth/login",
+        json={"username": "testuser", "password": "NewPass456!"},
+    )
+    assert resp.status_code == 200
+    assert "access_token" in resp.json()
+
+    # Verify old password no longer works
+    resp = await async_client.post(
+        "/api/v1/auth/login",
+        json={"username": "testuser", "password": "TestPass123!"},
+    )
+    assert resp.status_code == 401
+
+
+async def test_change_password_wrong_old(async_client: AsyncClient, test_user: dict):
+    """PUT /api/v1/settings/password with wrong old password should return 400."""
+    headers = {"Authorization": f"Bearer {test_user['token']}"}
+
+    resp = await async_client.put(
+        "/api/v1/settings/password",
+        json={"old_password": "WrongOldPass!", "new_password": "NewPass456!"},
+        headers=headers,
+    )
+    assert resp.status_code == 400
+
+
+async def test_change_password_too_short(async_client: AsyncClient, test_user: dict):
+    """PUT /api/v1/settings/password with short new password should return 422."""
+    headers = {"Authorization": f"Bearer {test_user['token']}"}
+
+    resp = await async_client.put(
+        "/api/v1/settings/password",
+        json={"old_password": "TestPass123!", "new_password": "ab"},
+        headers=headers,
+    )
+    assert resp.status_code == 422

--- a/backend/tests/test_smoke.py
+++ b/backend/tests/test_smoke.py
@@ -1,0 +1,64 @@
+"""Smoke tests to verify the test infrastructure works correctly."""
+
+
+async def test_health_check(async_client):
+    """The /api/v1/health endpoint should return 200."""
+    resp = await async_client.get("/api/v1/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+async def test_seed_models_available(async_client):
+    """The model list endpoint should return the 4 seeded models."""
+    resp = await async_client.get("/api/v1/models/")
+    assert resp.status_code == 200
+    models = resp.json()
+    assert len(models) == 4
+    model_ids = {m["model_id"] for m in models}
+    assert "qwen3.6-plus" in model_ids
+    assert "deepseek-v4-pro" in model_ids
+
+
+async def test_register_and_login(async_client):
+    """Register a user, then login with the same credentials."""
+    # Register
+    resp = await async_client.post(
+        "/api/v1/auth/register",
+        json={"username": "smokeuser", "password": "Smoke123!"},
+    )
+    assert resp.status_code == 200
+    assert "access_token" in resp.json()
+
+    # Login
+    resp = await async_client.post(
+        "/api/v1/auth/login",
+        json={"username": "smokeuser", "password": "Smoke123!"},
+    )
+    assert resp.status_code == 200
+    assert "access_token" in resp.json()
+
+
+async def test_test_user_fixture(test_user):
+    """The test_user fixture should provide a token and user info."""
+    assert "token" in test_user
+    assert "user" in test_user
+    assert test_user["user"]["username"] == "testuser"
+
+
+async def test_admin_user_fixture(admin_user):
+    """The admin_user fixture should have is_admin=True."""
+    assert admin_user["user"]["is_admin"] is True
+
+
+async def test_auth_headers_fixture(async_client, auth_headers):
+    """auth_headers should allow accessing protected endpoints."""
+    resp = await async_client.get("/api/v1/auth/me", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["username"] == "testuser"
+
+
+async def test_admin_headers_fixture(async_client, admin_headers):
+    """admin_headers should allow accessing protected endpoints as admin."""
+    resp = await async_client.get("/api/v1/auth/me", headers=admin_headers)
+    assert resp.status_code == 200
+    assert resp.json()["is_admin"] is True

--- a/backend/tests/test_usage.py
+++ b/backend/tests/test_usage.py
@@ -1,0 +1,42 @@
+"""Tests for usage and dashboard endpoints."""
+
+from httpx import AsyncClient
+
+
+async def test_usage_overview(async_client: AsyncClient, auth_headers: dict):
+    """GET /api/v1/usage/overview should return 200 with usage data."""
+    resp = await async_client.get("/api/v1/usage/overview", headers=auth_headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "total_cost" in data
+    assert "total_tokens" in data
+    assert "total_requests" in data
+    assert "period" in data
+
+
+async def test_usage_trend(async_client: AsyncClient, auth_headers: dict):
+    """GET /api/v1/usage/trend should return 200 with trend data list."""
+    resp = await async_client.get("/api/v1/usage/trend", headers=auth_headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+
+
+async def test_usage_models(async_client: AsyncClient, auth_headers: dict):
+    """GET /api/v1/usage/models should return 200 with model usage list."""
+    resp = await async_client.get("/api/v1/usage/models", headers=auth_headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+
+
+async def test_dashboard(async_client: AsyncClient, auth_headers: dict):
+    """GET /api/v1/dashboard/ should return 200 with balance + trend."""
+    resp = await async_client.get("/api/v1/dashboard/", headers=auth_headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "balance" in data
+    assert "recent_trend" in data
+    assert "total_cost_30d" in data
+    assert "total_requests_30d" in data
+    assert "activated_models" in data

--- a/frontend/e2e/apikeys.spec.ts
+++ b/frontend/e2e/apikeys.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect } from '@playwright/test';
+import {
+  saveScreenshot,
+  registerUser,
+  generateTestUsername,
+  waitForPageReady,
+} from './helpers';
+
+const TEST_PASSWORD = 'TestPass123!';
+
+test.describe('API Key 管理', () => {
+  let testUsername: string;
+
+  test.beforeAll(() => {
+    testUsername = generateTestUsername();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await registerUser(page, testUsername, TEST_PASSWORD);
+    await waitForPageReady(page);
+  });
+
+  test('导航到 API Key 页面', async ({ page }) => {
+    await page.getByText('API Key').click();
+    await page.waitForURL('**/api-keys');
+    await waitForPageReady(page);
+
+    await saveScreenshot(page, 'apikeys-page');
+
+    // 验证页面标题
+    await expect(page.getByText('API Key 管理')).toBeVisible();
+    // 验证创建按钮存在
+    await expect(page.getByRole('button', { name: '创建 Key' })).toBeVisible();
+  });
+
+  test('创建新 Key 并验证弹窗显示', async ({ page }) => {
+    await page.goto('/api-keys');
+    await waitForPageReady(page);
+
+    // 点击创建按钮
+    await page.getByRole('button', { name: '创建 Key' }).click();
+
+    // 等待弹窗出现
+    const modal = page.locator('.ant-modal');
+    await expect(modal).toBeVisible({ timeout: 10000 });
+
+    // 验证弹窗标题
+    await expect(page.getByText('API Key 已创建')).toBeVisible();
+
+    // 验证 key 内容在 textarea 中
+    const textarea = modal.locator('textarea');
+    await expect(textarea).toBeVisible();
+    const keyValue = await textarea.inputValue();
+    expect(keyValue.length).toBeGreaterThan(0);
+
+    await saveScreenshot(page, 'apikeys-created-modal');
+
+    // 关闭弹窗
+    await page.getByRole('button', { name: '我已保存' }).click();
+    await expect(modal).not.toBeVisible();
+
+    // 验证列表中显示已掩码的 key
+    const table = page.locator('.ant-table');
+    await expect(table).toBeVisible();
+    // 表格中应有至少一行数据
+    const rows = table.locator('.ant-table-row');
+    await expect(rows).toHaveCount(1, { timeout: 5000 });
+
+    await saveScreenshot(page, 'apikeys-list-with-key');
+  });
+
+  test('删除 Key 并验证列表更新', async ({ page }) => {
+    await page.goto('/api-keys');
+    await waitForPageReady(page);
+
+    // 确保列表中有 key（前一个测试创建的）
+    const table = page.locator('.ant-table');
+    await expect(table).toBeVisible();
+
+    // 如果没有 key，先创建一个
+    const rows = table.locator('.ant-table-row');
+    const rowCount = await rows.count();
+    if (rowCount === 0) {
+      await page.getByRole('button', { name: '创建 Key' }).click();
+      await expect(page.getByText('API Key 已创建')).toBeVisible({ timeout: 10000 });
+      await page.getByRole('button', { name: '我已保存' }).click();
+      await waitForPageReady(page);
+    }
+
+    // 点击删除按钮
+    await page.getByRole('button', { name: '删除' }).first().click();
+
+    // 确认删除（Popconfirm）
+    await page.getByRole('button', { name: '删除' }).nth(1).click();
+
+    // 等待删除完成
+    await waitForPageReady(page);
+
+    await saveScreenshot(page, 'apikeys-after-delete');
+  });
+});

--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from '@playwright/test';
+import {
+  saveScreenshot,
+  registerUser,
+  loginUser,
+  logoutUser,
+  generateTestUsername,
+  waitForPageReady,
+  expectURL,
+} from './helpers';
+
+const TEST_PASSWORD = 'TestPass123!';
+
+test.describe('认证流程', () => {
+  let testUsername: string;
+
+  test.beforeAll(() => {
+    testUsername = generateTestUsername();
+  });
+
+  test('访问登录页并截图', async ({ page }) => {
+    await page.goto('/login');
+    await waitForPageReady(page);
+
+    // 验证登录页元素
+    await expect(page.getByPlaceholder('用户名')).toBeVisible();
+    await expect(page.getByPlaceholder('密码')).toBeVisible();
+    await expect(page.getByRole('button', { name: '登录' })).toBeVisible();
+
+    await saveScreenshot(page, 'auth-login-page');
+  });
+
+  test('注册新用户并跳转到 Dashboard', async ({ page }) => {
+    await registerUser(page, testUsername, TEST_PASSWORD);
+
+    // 验证跳转到 Dashboard
+    await expectURL(page, '/dashboard');
+    await waitForPageReady(page);
+
+    // 验证 Dashboard 页面内容
+    await expect(page.getByText('控制台')).toBeVisible();
+
+    await saveScreenshot(page, 'auth-dashboard-after-register');
+  });
+
+  test('退出登录并验证返回登录页', async ({ page }) => {
+    // 先登录
+    await loginUser(page, testUsername, TEST_PASSWORD);
+    await waitForPageReady(page);
+
+    // 退出登录
+    await logoutUser(page);
+
+    // 验证返回登录页
+    await expectURL(page, '/login');
+    await expect(page.getByRole('button', { name: '登录' })).toBeVisible();
+
+    await saveScreenshot(page, 'auth-after-logout');
+  });
+
+  test('用已注册账号重新登录', async ({ page }) => {
+    await loginUser(page, testUsername, TEST_PASSWORD);
+
+    // 验证成功跳转 Dashboard
+    await expectURL(page, '/dashboard');
+    await waitForPageReady(page);
+    await expect(page.getByText('控制台')).toBeVisible();
+
+    await saveScreenshot(page, 'auth-relogin-success');
+  });
+
+  test('未登录访问受保护页面重定向到登录页', async ({ page }) => {
+    // 清除 localStorage 确保未登录状态
+    await page.goto('/login');
+    await page.evaluate(() => localStorage.clear());
+
+    // 尝试访问受保护页面
+    await page.goto('/dashboard');
+    await page.waitForURL('**/login', { timeout: 10000 });
+
+    await expectURL(page, '/login');
+    await saveScreenshot(page, 'auth-redirect-to-login');
+  });
+});

--- a/frontend/e2e/balance.spec.ts
+++ b/frontend/e2e/balance.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from '@playwright/test';
+import {
+  saveScreenshot,
+  registerUser,
+  generateTestUsername,
+  waitForPageReady,
+} from './helpers';
+
+const TEST_PASSWORD = 'TestPass123!';
+
+test.describe('余额充值', () => {
+  let testUsername: string;
+
+  test.beforeAll(() => {
+    testUsername = generateTestUsername();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await registerUser(page, testUsername, TEST_PASSWORD);
+    await waitForPageReady(page);
+  });
+
+  test('导航到余额页面并验证初始余额', async ({ page }) => {
+    await page.getByText('余额充值').click();
+    await page.waitForURL('**/balance');
+    await waitForPageReady(page);
+
+    await saveScreenshot(page, 'balance-page');
+
+    // 验证页面标题
+    await expect(page.getByRole('heading', { name: /余额充值/ })).toBeVisible();
+
+    // 验证余额卡片存在（显示"当前余额"标题）
+    await expect(page.getByText('当前余额')).toBeVisible();
+
+    // 验证模拟充值按钮
+    await expect(page.getByRole('button', { name: '模拟充值' })).toBeVisible();
+
+    // 验证充值记录表格
+    await expect(page.getByText('充值记录')).toBeVisible();
+  });
+
+  test('提交充值申请并验证历史记录', async ({ page }) => {
+    await page.goto('/balance');
+    await waitForPageReady(page);
+
+    // 点击充值按钮
+    await page.getByRole('button', { name: '模拟充值' }).click();
+
+    // 等待弹窗出现
+    const modal = page.locator('.ant-modal');
+    await expect(modal).toBeVisible({ timeout: 5000 });
+
+    // 验证弹窗标题
+    await expect(page.getByText('模拟充值').nth(1)).toBeVisible();
+
+    // 填写充值金额
+    const amountInput = modal.locator('.ant-input-number-input');
+    await amountInput.fill('100');
+
+    // 填写备注（可选）
+    await modal.getByPlaceholder('可选备注').fill('E2E 测试充值');
+
+    // 提交
+    await page.getByRole('button', { name: '提交充值申请' }).click();
+
+    // 等待弹窗关闭
+    await expect(modal).not.toBeVisible({ timeout: 10000 });
+    await waitForPageReady(page);
+
+    await saveScreenshot(page, 'balance-after-recharge');
+
+    // 验证充值历史中出现新记录（状态为待审批）
+    await expect(page.getByText('待审批')).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/frontend/e2e/dashboard.spec.ts
+++ b/frontend/e2e/dashboard.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '@playwright/test';
+import {
+  saveScreenshot,
+  registerUser,
+  generateTestUsername,
+  waitForPageReady,
+  expectURL,
+} from './helpers';
+
+const TEST_PASSWORD = 'TestPass123!';
+
+test.describe('仪表板', () => {
+  let testUsername: string;
+
+  test.beforeAll(() => {
+    testUsername = generateTestUsername();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await registerUser(page, testUsername, TEST_PASSWORD);
+    await waitForPageReady(page);
+  });
+
+  test('Dashboard 页面展示关键指标卡片', async ({ page }) => {
+    // 注册后自动在 Dashboard
+    await expectURL(page, '/dashboard');
+
+    await saveScreenshot(page, 'dashboard-page');
+
+    // 验证控制台标题
+    await expect(page.getByRole('heading', { name: '控制台' })).toBeVisible();
+
+    // 验证 4 个指标卡片存在
+    await expect(page.getByText('当前余额')).toBeVisible();
+    await expect(page.getByText('近7日消费')).toBeVisible();
+    await expect(page.getByText('近7日调用')).toBeVisible();
+    await expect(page.getByText('已开通模型')).toBeVisible();
+  });
+
+  test('验证趋势图表区域存在', async ({ page }) => {
+    await page.goto('/dashboard');
+    await waitForPageReady(page);
+
+    // 验证图表卡片标题
+    await expect(page.getByText('近7日费用趋势')).toBeVisible();
+
+    // 验证 Recharts 容器存在
+    const chartContainer = page.locator('.recharts-responsive-container');
+    await expect(chartContainer).toBeVisible({ timeout: 10000 });
+
+    await saveScreenshot(page, 'dashboard-chart');
+  });
+
+  test('点击余额卡片导航到余额页面', async ({ page }) => {
+    await page.goto('/dashboard');
+    await waitForPageReady(page);
+
+    // 点击"当前余额"卡片
+    const balanceCard = page.locator('.ant-card').filter({ hasText: '当前余额' });
+    await balanceCard.click();
+
+    // 验证跳转到余额页面
+    await page.waitForURL('**/balance', { timeout: 5000 });
+    await expectURL(page, '/balance');
+
+    await saveScreenshot(page, 'dashboard-navigate-to-balance');
+  });
+
+  test('点击已开通模型卡片导航到模型市场', async ({ page }) => {
+    await page.goto('/dashboard');
+    await waitForPageReady(page);
+
+    // 点击"已开通模型"卡片
+    const modelsCard = page.locator('.ant-card').filter({ hasText: '已开通模型' });
+    await modelsCard.click();
+
+    // 验证跳转到模型市场
+    await page.waitForURL('**/models', { timeout: 5000 });
+    await expectURL(page, '/models');
+
+    await saveScreenshot(page, 'dashboard-navigate-to-models');
+  });
+});

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -1,0 +1,128 @@
+import { Page, expect } from '@playwright/test';
+import path from 'path';
+
+// 截图保存目录
+const SCREENSHOTS_DIR = path.resolve(__dirname, '../../test-artifacts/screenshots');
+
+/**
+ * 保存截图到 test-artifacts/screenshots/ 目录
+ * @param page Playwright Page 对象
+ * @param name 截图文件名（不含扩展名）
+ */
+export async function saveScreenshot(page: Page, name: string): Promise<string> {
+  const filePath = path.join(SCREENSHOTS_DIR, `${name}.png`);
+  await page.screenshot({ path: filePath, fullPage: true });
+  return filePath;
+}
+
+/**
+ * 注册新用户
+ * @param page Playwright Page 对象
+ * @param username 用户名
+ * @param password 密码
+ * @param displayName 显示名称（可选）
+ */
+export async function registerUser(
+  page: Page,
+  username: string,
+  password: string,
+  displayName?: string
+): Promise<void> {
+  await page.goto('/register');
+  await page.waitForLoadState('networkidle');
+
+  // 填写用户名
+  await page.getByPlaceholder('用户名').fill(username);
+
+  // 填写显示名称（可选）
+  if (displayName) {
+    await page.getByPlaceholder('显示名称（可选）').fill(displayName);
+  }
+
+  // 填写密码
+  await page.getByPlaceholder('密码', { exact: true }).fill(password);
+
+  // 填写确认密码
+  await page.getByPlaceholder('确认密码').fill(password);
+
+  // 点击注册按钮
+  await page.getByRole('button', { name: '注册' }).click();
+
+  // 等待导航到 dashboard
+  await page.waitForURL('**/dashboard', { timeout: 10000 });
+}
+
+/**
+ * 登录用户
+ * @param page Playwright Page 对象
+ * @param username 用户名
+ * @param password 密码
+ */
+export async function loginUser(
+  page: Page,
+  username: string,
+  password: string
+): Promise<void> {
+  await page.goto('/login');
+  await page.waitForLoadState('networkidle');
+
+  // 填写用户名
+  await page.getByPlaceholder('用户名').fill(username);
+
+  // 填写密码
+  await page.getByPlaceholder('密码').fill(password);
+
+  // 点击登录按钮
+  await page.getByRole('button', { name: '登录' }).click();
+
+  // 等待导航到 dashboard
+  await page.waitForURL('**/dashboard', { timeout: 10000 });
+}
+
+/**
+ * 退出登录
+ * @param page Playwright Page 对象
+ */
+export async function logoutUser(page: Page): Promise<void> {
+  // 点击右上角用户头像打开下拉菜单
+  await page.locator('.ant-dropdown-trigger').click();
+  // 点击退出登录
+  await page.getByText('退出登录').click();
+  // 等待跳转到登录页
+  await page.waitForURL('**/login', { timeout: 5000 });
+}
+
+/**
+ * 等待页面加载完成（包含 API 请求）
+ * @param page Playwright Page 对象
+ */
+export async function waitForPageReady(page: Page): Promise<void> {
+  await page.waitForLoadState('networkidle');
+}
+
+/**
+ * 断言页面标题/文本存在
+ * @param page Playwright Page 对象
+ * @param text 期望的文本
+ */
+export async function expectTextVisible(page: Page, text: string): Promise<void> {
+  await expect(page.getByText(text).first()).toBeVisible({ timeout: 5000 });
+}
+
+/**
+ * 断言当前 URL 匹配
+ * @param page Playwright Page 对象
+ * @param urlPattern URL 模式
+ */
+export async function expectURL(page: Page, urlPattern: string): Promise<void> {
+  await expect(page).toHaveURL(new RegExp(urlPattern), { timeout: 5000 });
+}
+
+/**
+ * 生成唯一的测试用户名（避免冲突）
+ */
+export function generateTestUsername(): string {
+  const timestamp = Date.now();
+  const random = Math.random().toString(36).substring(2, 6);
+  return `test_${timestamp}_${random}`;
+}

--- a/frontend/e2e/models.spec.ts
+++ b/frontend/e2e/models.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from '@playwright/test';
+import {
+  saveScreenshot,
+  registerUser,
+  generateTestUsername,
+  waitForPageReady,
+} from './helpers';
+
+const TEST_PASSWORD = 'TestPass123!';
+
+test.describe('模型市场流程', () => {
+  let testUsername: string;
+
+  test.beforeAll(() => {
+    testUsername = generateTestUsername();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    // 注册并登录
+    await registerUser(page, testUsername, TEST_PASSWORD);
+    await waitForPageReady(page);
+  });
+
+  test('导航到模型市场页面并查看模型卡片', async ({ page }) => {
+    // 通过侧边栏导航到模型市场
+    await page.getByText('模型市场').click();
+    await page.waitForURL('**/models');
+    await waitForPageReady(page);
+
+    await saveScreenshot(page, 'models-market');
+
+    // 验证模型市场标题
+    await expect(page.getByRole('heading', { name: '模型市场' })).toBeVisible();
+
+    // 验证至少有 4 个模型卡片
+    const cards = page.locator('.ant-card');
+    await expect(cards).toHaveCount(4, { timeout: 10000 });
+  });
+
+  test('点击模型卡片进入详情页', async ({ page }) => {
+    await page.goto('/models');
+    await waitForPageReady(page);
+
+    // 点击第一个模型卡片
+    const firstCard = page.locator('.ant-card').first();
+    await firstCard.click();
+
+    // 等待导航到详情页
+    await page.waitForURL('**/models/*');
+    await waitForPageReady(page);
+
+    await saveScreenshot(page, 'models-detail');
+
+    // 验证详情页内容
+    await expect(page.getByText('返回模型市场')).toBeVisible();
+    await expect(page.getByText('Model ID')).toBeVisible();
+    await expect(page.getByText('接入代码示例')).toBeVisible();
+  });
+
+  test('激活模型并验证状态变化', async ({ page }) => {
+    await page.goto('/models');
+    await waitForPageReady(page);
+
+    // 点击第一个模型卡片进入详情
+    const firstCard = page.locator('.ant-card').first();
+    await firstCard.click();
+    await page.waitForURL('**/models/*');
+    await waitForPageReady(page);
+
+    // 点击"开通模型"按钮
+    const activateButton = page.getByRole('button', { name: '开通模型' });
+    await expect(activateButton).toBeVisible();
+    await activateButton.click();
+
+    // 等待操作完成，验证状态变为"已开通"
+    await expect(page.getByText('已开通')).toBeVisible({ timeout: 10000 });
+
+    await saveScreenshot(page, 'models-activated');
+
+    // 验证出现"关闭"按钮（表示已激活）
+    await expect(page.getByRole('button', { name: '关闭' })).toBeVisible();
+  });
+
+  test('返回模型市场验证激活标签显示', async ({ page }) => {
+    await page.goto('/models');
+    await waitForPageReady(page);
+
+    // 验证模型市场中有"已开通"标签
+    await expect(page.getByText('已开通').first()).toBeVisible({ timeout: 10000 });
+
+    await saveScreenshot(page, 'models-market-with-activation');
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@playwright/test": "^1.59.1",
         "@types/node": "^24.12.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -691,6 +692,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rc-component/async-validator": {
@@ -3795,6 +3812,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.59.1",
     "@types/node": "^24.12.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,  // 串行执行，因为测试之间有状态依赖
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+    screenshot: 'on',  // 每个测试都截图
+  },
+  outputDir: '../test-artifacts/playwright-results',
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        browserName: 'chromium',
+        viewport: { width: 1280, height: 720 },
+      },
+    },
+  ],
+  // 注意：不配置 webServer，因为需要手动启动前后端服务
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import ModelDetailPage from "./pages/ModelDetailPage";
 import ApiKeysPage from "./pages/ApiKeysPage";
 import BalancePage from "./pages/BalancePage";
 import UsagePage from "./pages/UsagePage";
+import SettingsPage from "./pages/SettingsPage";
 
 export default function App() {
   return (
@@ -40,7 +41,7 @@ export default function App() {
               <Route path="/api-keys" element={<ApiKeysPage />} />
               <Route path="/balance" element={<BalancePage />} />
               <Route path="/usage" element={<UsagePage />} />
-              <Route path="/settings" element={<DashboardPage />} />
+              <Route path="/settings" element={<SettingsPage />} />
             </Route>
 
             {/* Default redirect */}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import DashboardPage from "./pages/DashboardPage";
 import ModelMarketPage from "./pages/ModelMarketPage";
 import ModelDetailPage from "./pages/ModelDetailPage";
 import ApiKeysPage from "./pages/ApiKeysPage";
+import BalancePage from "./pages/BalancePage";
 
 export default function App() {
   return (
@@ -36,7 +37,7 @@ export default function App() {
               <Route path="/models/:modelId" element={<ModelDetailPage />} />
               {/* Placeholder routes for future phases */}
               <Route path="/api-keys" element={<ApiKeysPage />} />
-              <Route path="/balance" element={<DashboardPage />} />
+              <Route path="/balance" element={<BalancePage />} />
               <Route path="/usage" element={<DashboardPage />} />
               <Route path="/settings" element={<DashboardPage />} />
             </Route>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import ModelMarketPage from "./pages/ModelMarketPage";
 import ModelDetailPage from "./pages/ModelDetailPage";
 import ApiKeysPage from "./pages/ApiKeysPage";
 import BalancePage from "./pages/BalancePage";
+import UsagePage from "./pages/UsagePage";
 
 export default function App() {
   return (
@@ -38,7 +39,7 @@ export default function App() {
               {/* Placeholder routes for future phases */}
               <Route path="/api-keys" element={<ApiKeysPage />} />
               <Route path="/balance" element={<BalancePage />} />
-              <Route path="/usage" element={<DashboardPage />} />
+              <Route path="/usage" element={<UsagePage />} />
               <Route path="/settings" element={<DashboardPage />} />
             </Route>
 

--- a/frontend/src/api/apikeys.ts
+++ b/frontend/src/api/apikeys.ts
@@ -24,6 +24,11 @@ export async function listApiKeys(): Promise<ApiKeyItem[]> {
   return data;
 }
 
+export async function copyApiKey(keyId: number): Promise<ApiKeyCreated> {
+  const { data } = await client.post<ApiKeyCreated>(`/api-keys/${keyId}/copy`);
+  return data;
+}
+
 export async function deleteApiKey(keyId: number): Promise<void> {
   await client.delete(`/api-keys/${keyId}`);
 }

--- a/frontend/src/api/balance.ts
+++ b/frontend/src/api/balance.ts
@@ -1,0 +1,37 @@
+import client from "./client";
+
+export interface BalanceInfo {
+  balance: number;
+}
+
+export interface RechargeRecord {
+  id: number;
+  amount: number;
+  balance_before: number;
+  balance_after: number;
+  status: string;
+  remark: string | null;
+  created_at: string;
+  completed_at: string | null;
+}
+
+export async function getBalance(): Promise<BalanceInfo> {
+  const { data } = await client.get<BalanceInfo>("/balance/");
+  return data;
+}
+
+export async function submitRecharge(
+  amount: number,
+  remark?: string
+): Promise<RechargeRecord> {
+  const { data } = await client.post<RechargeRecord>("/balance/recharge", {
+    amount,
+    remark,
+  });
+  return data;
+}
+
+export async function getRechargeHistory(): Promise<RechargeRecord[]> {
+  const { data } = await client.get<RechargeRecord[]>("/balance/history");
+  return data;
+}

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -1,0 +1,11 @@
+import client from "./client";
+
+export async function changePassword(
+  oldPassword: string,
+  newPassword: string
+): Promise<void> {
+  await client.put("/settings/password", {
+    old_password: oldPassword,
+    new_password: newPassword,
+  });
+}

--- a/frontend/src/api/usage.ts
+++ b/frontend/src/api/usage.ts
@@ -1,0 +1,53 @@
+import client from "./client";
+
+export interface UsageOverview {
+  total_cost: number;
+  total_tokens: number;
+  total_requests: number;
+  period: string;
+}
+
+export interface UsageTrendItem {
+  date: string;
+  cost: number;
+  tokens: number;
+  requests: number;
+}
+
+export interface ModelUsageItem {
+  model_id: string;
+  model_name: string;
+  cost: number;
+  tokens: number;
+  requests: number;
+}
+
+export interface DashboardData {
+  balance: number;
+  total_cost_30d: number;
+  total_requests_30d: number;
+  activated_models: number;
+  recent_trend: UsageTrendItem[];
+}
+
+export async function getUsageOverview(): Promise<UsageOverview> {
+  const { data } = await client.get<UsageOverview>("/usage/overview");
+  return data;
+}
+
+export async function getUsageTrend(days = 7): Promise<UsageTrendItem[]> {
+  const { data } = await client.get<UsageTrendItem[]>("/usage/trend", {
+    params: { days },
+  });
+  return data;
+}
+
+export async function getModelUsage(): Promise<ModelUsageItem[]> {
+  const { data } = await client.get<ModelUsageItem[]>("/usage/models");
+  return data;
+}
+
+export async function getDashboard(): Promise<DashboardData> {
+  const { data } = await client.get<DashboardData>("/dashboard/");
+  return data;
+}

--- a/frontend/src/pages/ApiKeysPage.tsx
+++ b/frontend/src/pages/ApiKeysPage.tsx
@@ -21,6 +21,7 @@ import {
 import {
   createApiKey,
   listApiKeys,
+  copyApiKey,
   deleteApiKey,
   type ApiKeyItem,
 } from "../api/apikeys";
@@ -74,6 +75,22 @@ export default function ApiKeysPage() {
     });
   };
 
+  const handleCopyPreview = async (record: ApiKeyItem) => {
+    if (record.id === null) return;
+    try {
+      const result = await copyApiKey(record.id);
+      if (result.api_key) {
+        navigator.clipboard.writeText(result.api_key).then(() => {
+          message.success("完整 API Key 已复制到剪贴板");
+        });
+      } else {
+        message.warning("未能获取完整 API Key");
+      }
+    } catch (err: any) {
+      message.error(err.response?.data?.detail || "复制失败");
+    }
+  };
+
   const columns = [
     {
       title: "API Key",
@@ -102,18 +119,28 @@ export default function ApiKeysPage() {
       key: "action",
       width: 100,
       render: (_: unknown, record: ApiKeyItem) => (
-        <Popconfirm
-          title="确定删除此 API Key?"
-          description="删除后将无法恢复，使用该 Key 的调用将立即失效。"
-          onConfirm={() => record.id !== null && handleDelete(record.id)}
-          okText="删除"
-          cancelText="取消"
-          okButtonProps={{ danger: true }}
-        >
-          <Button type="link" danger icon={<DeleteOutlined />} size="small">
-            删除
+        <Space>
+          <Button
+            type="link"
+            icon={<CopyOutlined />}
+            size="small"
+            onClick={() => handleCopyPreview(record)}
+          >
+            复制
           </Button>
-        </Popconfirm>
+          <Popconfirm
+            title="确定删除此 API Key?"
+            description="删除后将无法恢复，使用该 Key 的调用将立即失效。"
+            onConfirm={() => record.id !== null && handleDelete(record.id)}
+            okText="删除"
+            cancelText="取消"
+            okButtonProps={{ danger: true }}
+          >
+            <Button type="link" danger icon={<DeleteOutlined />} size="small">
+              删除
+            </Button>
+          </Popconfirm>
+        </Space>
       ),
     },
   ];

--- a/frontend/src/pages/BalancePage.tsx
+++ b/frontend/src/pages/BalancePage.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useState } from "react";
+import {
+  Typography,
+  Card,
+  Button,
+  Table,
+  Modal,
+  Form,
+  InputNumber,
+  Input,
+  Tag,
+  Statistic,
+  message,
+  Space,
+  Spin,
+} from "antd";
+import { WalletOutlined, PlusOutlined } from "@ant-design/icons";
+import {
+  getBalance,
+  submitRecharge,
+  getRechargeHistory,
+  type BalanceInfo,
+  type RechargeRecord,
+} from "../api/balance";
+
+const { Title } = Typography;
+
+const statusMap: Record<string, { color: string; label: string }> = {
+  pending: { color: "orange", label: "待审批" },
+  completed: { color: "green", label: "已完成" },
+  failed: { color: "red", label: "已拒绝" },
+};
+
+export default function BalancePage() {
+  const [balance, setBalance] = useState<BalanceInfo | null>(null);
+  const [records, setRecords] = useState<RechargeRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [submitLoading, setSubmitLoading] = useState(false);
+  const [form] = Form.useForm();
+
+  const fetchData = async () => {
+    setLoading(true);
+    try {
+      const [b, r] = await Promise.all([getBalance(), getRechargeHistory()]);
+      setBalance(b);
+      setRecords(r);
+    } catch {
+      message.error("加载数据失败");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  const handleSubmit = async (values: { amount: number; remark?: string }) => {
+    setSubmitLoading(true);
+    try {
+      await submitRecharge(values.amount, values.remark);
+      message.success("充值申请已提交，等待管理员审批");
+      setModalOpen(false);
+      form.resetFields();
+      fetchData();
+    } catch (err: any) {
+      message.error(err.response?.data?.detail || "提交失败");
+    } finally {
+      setSubmitLoading(false);
+    }
+  };
+
+  const columns = [
+    {
+      title: "金额",
+      dataIndex: "amount",
+      key: "amount",
+      render: (v: number) => `¥ ${v.toFixed(2)}`,
+    },
+    {
+      title: "状态",
+      dataIndex: "status",
+      key: "status",
+      render: (v: string) => {
+        const s = statusMap[v] || { color: "default", label: v };
+        return <Tag color={s.color}>{s.label}</Tag>;
+      },
+    },
+    {
+      title: "充值前余额",
+      dataIndex: "balance_before",
+      key: "balance_before",
+      render: (v: number) => `¥ ${v.toFixed(2)}`,
+    },
+    {
+      title: "充值后余额",
+      dataIndex: "balance_after",
+      key: "balance_after",
+      render: (v: number) => `¥ ${v.toFixed(2)}`,
+    },
+    {
+      title: "备注",
+      dataIndex: "remark",
+      key: "remark",
+      render: (v: string | null) => v || "-",
+    },
+    {
+      title: "申请时间",
+      dataIndex: "created_at",
+      key: "created_at",
+      render: (v: string) => new Date(v).toLocaleString("zh-CN"),
+    },
+  ];
+
+  if (loading) {
+    return (
+      <div style={{ textAlign: "center", padding: 80 }}>
+        <Spin size="large" />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: 24,
+        }}
+      >
+        <Title level={3} style={{ margin: 0 }}>
+          <WalletOutlined style={{ marginRight: 8 }} />
+          余额充值
+        </Title>
+        <Button
+          type="primary"
+          icon={<PlusOutlined />}
+          onClick={() => setModalOpen(true)}
+        >
+          模拟充值
+        </Button>
+      </div>
+
+      <Card style={{ marginBottom: 24 }}>
+        <Statistic
+          title="当前余额"
+          value={balance?.balance ?? 0}
+          precision={2}
+          prefix="¥"
+          valueStyle={{ color: "#1677ff", fontSize: 36 }}
+        />
+      </Card>
+
+      <Card title="充值记录">
+        <Table
+          columns={columns}
+          dataSource={records}
+          rowKey="id"
+          pagination={{ pageSize: 10 }}
+          locale={{ emptyText: "暂无充值记录" }}
+        />
+      </Card>
+
+      <Modal
+        title="模拟充值"
+        open={modalOpen}
+        onCancel={() => setModalOpen(false)}
+        footer={null}
+      >
+        <Form form={form} onFinish={handleSubmit} layout="vertical">
+          <Form.Item
+            name="amount"
+            label="充值金额"
+            rules={[{ required: true, message: "请输入充值金额" }]}
+          >
+            <InputNumber
+              min={1}
+              max={100000}
+              precision={2}
+              prefix="¥"
+              style={{ width: "100%" }}
+              placeholder="请输入充值金额"
+            />
+          </Form.Item>
+          <Form.Item name="remark" label="备注">
+            <Input.TextArea rows={2} placeholder="可选备注" />
+          </Form.Item>
+          <Form.Item>
+            <Space>
+              <Button
+                type="primary"
+                htmlType="submit"
+                loading={submitLoading}
+              >
+                提交充值申请
+              </Button>
+              <Button onClick={() => setModalOpen(false)}>取消</Button>
+            </Space>
+          </Form.Item>
+        </Form>
+      </Modal>
+    </div>
+  );
+}

--- a/frontend/src/pages/BalancePage.tsx
+++ b/frontend/src/pages/BalancePage.tsx
@@ -60,7 +60,7 @@ export default function BalancePage() {
     setSubmitLoading(true);
     try {
       await submitRecharge(values.amount, values.remark);
-      message.success("充值申请已提交，等待管理员审批");
+      message.success("充值成功");
       setModalOpen(false);
       form.resetFields();
       fetchData();
@@ -195,7 +195,7 @@ export default function BalancePage() {
                 htmlType="submit"
                 loading={submitLoading}
               >
-                提交充值申请
+                确认充值
               </Button>
               <Button onClick={() => setModalOpen(false)}>取消</Button>
             </Space>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,12 +1,118 @@
-import { Typography } from "antd";
+import { useEffect, useState } from "react";
+import { Card, Col, Row, Statistic, Typography, Spin } from "antd";
+import {
+  WalletOutlined,
+  ThunderboltOutlined,
+  AppstoreOutlined,
+  DollarOutlined,
+} from "@ant-design/icons";
+import { useNavigate } from "react-router-dom";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import { getDashboard, type DashboardData } from "../api/usage";
+
+const { Title } = Typography;
 
 export default function DashboardPage() {
+  const [data, setData] = useState<DashboardData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    getDashboard()
+      .then(setData)
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div style={{ textAlign: "center", padding: 80 }}>
+        <Spin size="large" />
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
   return (
     <div>
-      <Typography.Title level={3}>控制台</Typography.Title>
-      <Typography.Paragraph>
-        欢迎使用 ModelRouter Portal，这里将展示余额、消费和调用概览。
-      </Typography.Paragraph>
+      <Title level={3}>控制台</Title>
+
+      <Row gutter={[16, 16]} style={{ marginBottom: 24 }}>
+        <Col xs={24} sm={12} lg={6}>
+          <Card hoverable onClick={() => navigate("/balance")}>
+            <Statistic
+              title="当前余额"
+              value={data.balance}
+              precision={2}
+              prefix={<WalletOutlined style={{ color: "#1677ff" }} />}
+              suffix="元"
+            />
+          </Card>
+        </Col>
+        <Col xs={24} sm={12} lg={6}>
+          <Card hoverable onClick={() => navigate("/usage")}>
+            <Statistic
+              title="近7日消费"
+              value={data.total_cost_30d}
+              precision={2}
+              prefix={<DollarOutlined style={{ color: "#fa8c16" }} />}
+              suffix="元"
+            />
+          </Card>
+        </Col>
+        <Col xs={24} sm={12} lg={6}>
+          <Card hoverable onClick={() => navigate("/usage")}>
+            <Statistic
+              title="近7日调用"
+              value={data.total_requests_30d}
+              prefix={<ThunderboltOutlined style={{ color: "#52c41a" }} />}
+              suffix="次"
+            />
+          </Card>
+        </Col>
+        <Col xs={24} sm={12} lg={6}>
+          <Card hoverable onClick={() => navigate("/models")}>
+            <Statistic
+              title="已开通模型"
+              value={data.activated_models}
+              prefix={<AppstoreOutlined style={{ color: "#722ed1" }} />}
+              suffix="个"
+            />
+          </Card>
+        </Col>
+      </Row>
+
+      <Card title="近7日费用趋势">
+        <ResponsiveContainer width="100%" height={300}>
+          <LineChart data={data.recent_trend}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis
+              dataKey="date"
+              tickFormatter={(v: string) => v.slice(5)}
+            />
+            <YAxis />
+            <Tooltip
+              formatter={(value: number) => [`¥ ${value.toFixed(2)}`, "费用"]}
+              labelFormatter={(label: string) => `日期: ${label}`}
+            />
+            <Line
+              type="monotone"
+              dataKey="cost"
+              stroke="#1677ff"
+              strokeWidth={2}
+              dot={{ r: 4 }}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </Card>
     </div>
   );
 }

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,0 +1,90 @@
+import { useState } from "react";
+import { Typography, Card, Form, Input, Button, message } from "antd";
+import { SettingOutlined, LockOutlined } from "@ant-design/icons";
+import { changePassword } from "../api/settings";
+
+const { Title } = Typography;
+
+export default function SettingsPage() {
+  const [loading, setLoading] = useState(false);
+  const [form] = Form.useForm();
+
+  const handleSubmit = async (values: {
+    old_password: string;
+    new_password: string;
+  }) => {
+    setLoading(true);
+    try {
+      await changePassword(values.old_password, values.new_password);
+      message.success("密码修改成功");
+      form.resetFields();
+    } catch (err: any) {
+      message.error(err.response?.data?.detail || "修改失败");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div>
+      <Title level={3}>
+        <SettingOutlined style={{ marginRight: 8 }} />
+        账户设置
+      </Title>
+
+      <Card title="修改密码" style={{ maxWidth: 500 }}>
+        <Form form={form} onFinish={handleSubmit} layout="vertical">
+          <Form.Item
+            name="old_password"
+            label="当前密码"
+            rules={[{ required: true, message: "请输入当前密码" }]}
+          >
+            <Input.Password
+              prefix={<LockOutlined />}
+              placeholder="输入当前密码"
+            />
+          </Form.Item>
+          <Form.Item
+            name="new_password"
+            label="新密码"
+            rules={[
+              { required: true, message: "请输入新密码" },
+              { min: 6, message: "密码至少6个字符" },
+            ]}
+          >
+            <Input.Password
+              prefix={<LockOutlined />}
+              placeholder="输入新密码"
+            />
+          </Form.Item>
+          <Form.Item
+            name="confirm"
+            label="确认新密码"
+            dependencies={["new_password"]}
+            rules={[
+              { required: true, message: "请确认新密码" },
+              ({ getFieldValue }) => ({
+                validator(_, value) {
+                  if (!value || getFieldValue("new_password") === value) {
+                    return Promise.resolve();
+                  }
+                  return Promise.reject(new Error("两次输入的密码不一致"));
+                },
+              }),
+            ]}
+          >
+            <Input.Password
+              prefix={<LockOutlined />}
+              placeholder="再次输入新密码"
+            />
+          </Form.Item>
+          <Form.Item>
+            <Button type="primary" htmlType="submit" loading={loading}>
+              修改密码
+            </Button>
+          </Form.Item>
+        </Form>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/pages/UsagePage.tsx
+++ b/frontend/src/pages/UsagePage.tsx
@@ -1,0 +1,192 @@
+import { useEffect, useState } from "react";
+import {
+  Typography,
+  Card,
+  Row,
+  Col,
+  Statistic,
+  Table,
+  Spin,
+  message,
+} from "antd";
+import { BarChartOutlined } from "@ant-design/icons";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+} from "recharts";
+import {
+  getUsageOverview,
+  getUsageTrend,
+  getModelUsage,
+  type UsageOverview,
+  type UsageTrendItem,
+  type ModelUsageItem,
+} from "../api/usage";
+
+const { Title, Text } = Typography;
+
+export default function UsagePage() {
+  const [overview, setOverview] = useState<UsageOverview | null>(null);
+  const [trend, setTrend] = useState<UsageTrendItem[]>([]);
+  const [modelUsage, setModelUsage] = useState<ModelUsageItem[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    Promise.all([getUsageOverview(), getUsageTrend(7), getModelUsage()])
+      .then(([o, t, m]) => {
+        setOverview(o);
+        setTrend(t);
+        setModelUsage(m);
+      })
+      .catch(() => message.error("加载用量数据失败"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div style={{ textAlign: "center", padding: 80 }}>
+        <Spin size="large" />
+      </div>
+    );
+  }
+
+  const modelColumns = [
+    { title: "模型", dataIndex: "model_name", key: "model_name" },
+    {
+      title: "Model ID",
+      dataIndex: "model_id",
+      key: "model_id",
+      render: (v: string) => <Text code>{v}</Text>,
+    },
+    {
+      title: "费用",
+      dataIndex: "cost",
+      key: "cost",
+      sorter: (a: ModelUsageItem, b: ModelUsageItem) => a.cost - b.cost,
+      render: (v: number) => `¥ ${v.toFixed(2)}`,
+    },
+    {
+      title: "Token 数",
+      dataIndex: "tokens",
+      key: "tokens",
+      sorter: (a: ModelUsageItem, b: ModelUsageItem) => a.tokens - b.tokens,
+      render: (v: number) => v.toLocaleString(),
+    },
+    {
+      title: "请求数",
+      dataIndex: "requests",
+      key: "requests",
+      sorter: (a: ModelUsageItem, b: ModelUsageItem) =>
+        a.requests - b.requests,
+      render: (v: number) => v.toLocaleString(),
+    },
+  ];
+
+  return (
+    <div>
+      <Title level={3}>
+        <BarChartOutlined style={{ marginRight: 8 }} />
+        用量统计
+      </Title>
+
+      {overview && (
+        <Row gutter={[16, 16]} style={{ marginBottom: 24 }}>
+          <Col xs={24} sm={8}>
+            <Card>
+              <Statistic
+                title={`${overview.period} 总费用`}
+                value={overview.total_cost}
+                precision={2}
+                prefix="¥"
+              />
+            </Card>
+          </Col>
+          <Col xs={24} sm={8}>
+            <Card>
+              <Statistic
+                title="总 Token 数"
+                value={overview.total_tokens}
+                formatter={(v) => Number(v).toLocaleString()}
+              />
+            </Card>
+          </Col>
+          <Col xs={24} sm={8}>
+            <Card>
+              <Statistic
+                title="总请求数"
+                value={overview.total_requests}
+                formatter={(v) => Number(v).toLocaleString()}
+              />
+            </Card>
+          </Col>
+        </Row>
+      )}
+
+      <Row gutter={[16, 16]} style={{ marginBottom: 24 }}>
+        <Col xs={24} lg={12}>
+          <Card title="费用趋势 (近7日)">
+            <ResponsiveContainer width="100%" height={260}>
+              <LineChart data={trend}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis
+                  dataKey="date"
+                  tickFormatter={(v: string) => v.slice(5)}
+                />
+                <YAxis />
+                <Tooltip
+                  formatter={(value: number) => [
+                    `¥ ${value.toFixed(2)}`,
+                    "费用",
+                  ]}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="cost"
+                  stroke="#1677ff"
+                  strokeWidth={2}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </Card>
+        </Col>
+        <Col xs={24} lg={12}>
+          <Card title="请求趋势 (近7日)">
+            <ResponsiveContainer width="100%" height={260}>
+              <BarChart data={trend}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis
+                  dataKey="date"
+                  tickFormatter={(v: string) => v.slice(5)}
+                />
+                <YAxis />
+                <Tooltip
+                  formatter={(value: number) => [
+                    value.toLocaleString(),
+                    "请求数",
+                  ]}
+                />
+                <Bar dataKey="requests" fill="#52c41a" />
+              </BarChart>
+            </ResponsiveContainer>
+          </Card>
+        </Col>
+      </Row>
+
+      <Card title="模型用量明细">
+        <Table
+          columns={modelColumns}
+          dataSource={modelUsage}
+          rowKey="model_id"
+          pagination={false}
+        />
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -5,6 +5,7 @@ export interface UserInfo {
   client_id: number | null;
   is_active: boolean;
   is_admin: boolean;
+  balance: number;
 }
 
 export interface TokenResponse {


### PR DESCRIPTION
## Summary

This PR includes the final polish changes for Phase 6, covering API Key management fixes, Alibaba Cloud client binding on registration, and a comprehensive test suite.

## Changes

### Backend
- **Fixed API Key field mapping**: Corrected `api_key` → `key` and `api_key_preview` → `key_preview` to match Alibaba Cloud SDK `ApiKeyDTO` structure
- **Added `ModelRouterCopyApiKey` integration**: New `POST /api-keys/{id}/copy` endpoint to retrieve full API Key via Alibaba Cloud SDK
- **Added client creation on registration**: `auth.register` now calls `ModelRouterCreateClient` and binds `client_id` / `client_uuid` to the local user
- **Added `client_service.py`**: Encapsulates Alibaba Cloud client creation logic
- **Fixed recharge flow**: Instant completion without admin approval
- **Fixed `delete_api_key`**: Passes `str(key_id)` to match SDK signature

### Frontend
- **API Key copy button**: List items now have a "Copy" button that fetches the full key via the new copy endpoint
- **Recharge instant completion**: Removed pending/approval state, recharge completes immediately
- **Lint fixes**: Resolved various ESLint issues

### Testing
- Added full backend pytest suite (49 tests): auth, apikeys, models, balance, usage, settings, security, smoke
- Added Playwright E2E tests: auth, apikeys, models, balance, dashboard
- Added `conftest.py` with global mock for `create_cloud_client` to allow tests to run without real Alibaba Cloud credentials

## Verification
- All 49 backend tests pass
- Backend service starts correctly with auto-reload
- Frontend dev server starts correctly